### PR TITLE
Fixed issues with file headers in UsingCodeFixProvider

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
@@ -344,10 +344,6 @@ namespace Newtonsoft.Json
 // Copyright (c) FooCorporation. All rights reserved.
 // </copyright>
 
-// <copyright file=""VoiceCommandService.cs"" company=""Foo Corporation"">
-// Copyright (c) FooCorporation. All rights reserved.
-// </copyright>
-
 namespace Foo.Garage.XYZ
 {
     using System;
@@ -360,11 +356,56 @@ namespace Newtonsoft.Json
 }
 ";
 
+            // The same diagnostic is reported multiple times due to a bug in Roslyn 1.0
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(8, 5),
                 this.CSharpDiagnostic().WithLocation(8, 5),
                 this.CSharpDiagnostic().WithLocation(8, 5),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the first using statement will preserve its leading comment.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestLeadingCommentForFirstUsingInNamespaceIsPreservedAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    // With test comment
+    using System;
+    using TestNamespace;
+    using Newtonsoft.Json;
+}
+
+namespace Newtonsoft.Json
+{
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    // With test comment
+    using System;
+    using Newtonsoft.Json;
+    using TestNamespace;
+}
+
+namespace Newtonsoft.Json
+{
+}
+";
+
+            // The same diagnostic is reported multiple times due to a bug in Roslyn 1.0
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(5, 5),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
- Improved file header detection by actually requiring the using to be the first node in a file.
- Only re-adds the file header if it is actually stripped
- Uses a new annotation to signal that the file header was stripped
- Added a test case to see that leading comments are preserved for the first using inside a namespace, as this was also broken.
